### PR TITLE
v2.3.7 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Feature expansion of guest WiFi networks on AsusWRT-Merlin, including, but not l
 
 ## Supported Models
 
-All models running Asuswrt-Merlin 384.5 or later, and have the Guest Network feature should be supported by this script. That being said, I will maintain a list of confirmed supported models as per user reports.
+All models running Asuswrt-Merlin 384.5/john9527's fork 374.43_32D6j9527 and later, and have the Guest Network feature should be supported by this script. That being said, I will maintain a list of confirmed supported models as per user reports.
 * RT-AC56U
 * RT-AC66U
 * RT-AC68U

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Feature expansion of guest WiFi networks on AsusWRT-Merlin, including, but not l
 
 ## Supported Models
 
-All Asus models that are supported by Merlin, and have the Guest Network feature should be supported by this script. That being said, I will maintain a list of confirmed supported models as per user reports.
+All models running Asuswrt-Merlin 384.5 or later, and have the Guest Network feature should be supported by this script. That being said, I will maintain a list of confirmed supported models as per user reports.
 * RT-AC56U
 * RT-AC66U
 * RT-AC68U

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # YazFi - enhanced AsusWRT-Merlin Guest WiFi Networks
-## v2.3.6
+## v2.3.7
 ## About
 
 Feature expansion of guest WiFi networks on AsusWRT-Merlin, including, but not limited to:
@@ -14,9 +14,11 @@ Feature expansion of guest WiFi networks on AsusWRT-Merlin, including, but not l
 
 All Asus models that are supported by Merlin, and have the Guest Network feature should be supported by this script. That being said, I will maintain a list of confirmed supported models as per user reports.
 * RT-AC56U
+* RT-AC66U
 * RT-AC68U
 * RT-AC86U
 * RT-AC87U (2.4GHz guests only)
+* RT-AC88U
 * RT-AC3200
 * RT-AC5300
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ Using your preferred SSH client/terminal, copy and paste the following command, 
 /jffs/scripts/YazFi update
 ```
 
+To force a re-install of the current version, use the following command instead (requires YazFi 2.3.7 or later):
+
+```
+/jffs/scripts/YazFi forceupdate
+```
+
 ## Help
 
 Please post about any issues and problems here: https://www.snbforums.com/threads/yazfi-enhanced-asuswrt-merlin-guest-wifi-networks.45924/
@@ -89,19 +95,6 @@ Not implemented
 
 ### wl01_CLIENTISOLATION
 Not implemented
-
-## How do I enable/disable the experimental DHCP Blocking feature?
-To enable:
-```
-/jffs/scripts/YazFi blockdhcp
-```
-
-To disable:
-```
-/jffs/scripts/YazFi unblockdhcp
-```
-
-A file is created in /jffs/configs/YazFi to enable this feature. It is implemented by adding no-dhcp-interface to /jffs/configs/dnsmasq.conf.add , and removing it using /jffs/scripts/dnsmasq.postconf once YazFi has completed initialisation.
 
 ## Known Issues/Limitations
 

--- a/YazFi
+++ b/YazFi
@@ -126,7 +126,7 @@ Auto_ServiceEvent () {
 		create)
 			if [ -f /jffs/scripts/service-event ]; then
 				STARTUPLINECOUNT=$(grep -c '# '"$YAZFI_NAME"' Guest Networks' /jffs/scripts/service-event)
-				STARTUPLINECOUNTEX=$(grep -cx "/jffs/scripts/$YAZFI_NAME bounceclients"' "$1" "$2"'' # '"$YAZFI_NAME"' Guest Networks' /jffs/scripts/service-event)
+				STARTUPLINECOUNTEX=$(grep -cx "/jffs/scripts/$YAZFI_NAME bounceclients"' "$1" "$2" &'' # '"$YAZFI_NAME"' Guest Networks' /jffs/scripts/service-event)
 				
 				if [ "$STARTUPLINECOUNT" -gt 1 ] || { [ "$STARTUPLINECOUNTEX" -eq 0 ] && [ "$STARTUPLINECOUNT" -gt 0 ]; }; then
 					Print_Output "true" "Purging duplicate/invalid entries for $YAZFI_NAME in service-event"
@@ -136,13 +136,13 @@ Auto_ServiceEvent () {
 				if [ "$STARTUPLINECOUNTEX" -eq 0 ]; then
 					Print_Output "true" "Adding $YAZFI_NAME to service-event"
 					echo "" >> /jffs/scripts/service-event
-					echo "/jffs/scripts/$YAZFI_NAME bounceclients"' "$1" "$2"'' # '"$YAZFI_NAME"' Guest Networks' >> /jffs/scripts/service-event
+					echo "/jffs/scripts/$YAZFI_NAME bounceclients"' "$1" "$2" &'' # '"$YAZFI_NAME"' Guest Networks' >> /jffs/scripts/service-event
 				fi
 			else
 				Print_Output "true" "service-event doesn't exist, creating"
 				echo "#!/bin/sh" > /jffs/scripts/service-event
 				echo "" >> /jffs/scripts/service-event
-				echo "/jffs/scripts/$YAZFI_NAME bounceclients"' "$1" "$2"'' # '"$YAZFI_NAME"' Guest Networks' >> /jffs/scripts/service-event
+				echo "/jffs/scripts/$YAZFI_NAME bounceclients"' "$1" "$2" &'' # '"$YAZFI_NAME"' Guest Networks' >> /jffs/scripts/service-event
 				chmod 0755 /jffs/scripts/service-event
 			fi
 		;;

--- a/YazFi
+++ b/YazFi
@@ -115,7 +115,7 @@ Iface_Manage () {
 }
 
 Iface_BounceClients () {
-	Print_Output "false" "De-authenticating YazFi Guest WiFi clients..." "$PASS"
+	Print_Output "true" "Forcing YazFi Guest WiFi clients to reauthenticate" "$PASS"
 	
 	for IFACE in $IFACELIST; do
 		wl -i "$IFACE" deauthenticate  >/dev/null 2>&1
@@ -1059,8 +1059,13 @@ case "$1" in
 		exit 0
 	;;
 	bounceclients)
-		if [ "$2" = "restart" ] && [ "$3" = "wireless" ]; then
+		if [ -z "$2" ] && [ -z "$3" ]; then
 			Check_Lock
+			Iface_BounceClients
+			Clear_Lock
+		elif [ "$2" = "restart" ] && [ "$3" = "wireless" ]; then
+			Check_Lock
+			Print_Output "true" "Wireless restarted - sleeping 30s before running YazFi" "$PASS"
 			sleep 30
 			Config_Networks
 			Iface_BounceClients

--- a/YazFi
+++ b/YazFi
@@ -15,7 +15,7 @@ readonly YAZFI_NAME="YazFi"
 readonly YAZFI_CONF_OLD="/jffs/configs/$YAZFI_NAME.config"
 readonly YAZFI_CONF="/jffs/configs/$YAZFI_NAME/$YAZFI_NAME.config"
 readonly YAZFI_VERSION="v2.3.7"
-readonly YAZFI_BRANCH="testing"
+readonly YAZFI_BRANCH="master"
 readonly YAZFI_REPO="https://raw.githubusercontent.com/jackyaz/YazFi/""$YAZFI_BRANCH""/YazFi"
 ### End of script variables ###
 

--- a/YazFi
+++ b/YazFi
@@ -999,7 +999,10 @@ Config_Networks () {
 	
 	DHCP_Conf save 2>/dev/null
 	
+	#Clean DHCP blocking
 	rm -f "$YAZFI_BLOCKDHCPFILE" 2>/dev/null
+	Auto_Block_DHCP delete 2>/dev/null
+	DHCP_Conf_Block delete 2>/dev/null
 	
 	Print_Output "true" "YazFi $YAZFI_VERSION completed successfully" "$PASS"
 }

--- a/YazFi
+++ b/YazFi
@@ -999,9 +999,12 @@ Config_Networks () {
 	DHCP_Conf save 2>/dev/null
 	
 	#Clean DHCP blocking
-	Auto_Block_DHCP delete 2>/dev/null
-	DHCP_Conf_Block delete 2>/dev/null	
-	rm -f "$YAZFI_BLOCKDHCPFILE" 2>/dev/null
+	if [ "$BLOCKDHCP" = "true" ]; then
+		Auto_Block_DHCP delete 2>/dev/null
+		DHCP_Conf_Block delete 2>/dev/null
+		rm -f "$YAZFI_BLOCKDHCPFILE" 2>/dev/null
+		service restart_dnsmasq >/dev/null 2>&1
+	fi
 	
 	Print_Output "true" "YazFi $YAZFI_VERSION completed successfully" "$PASS"
 }

--- a/YazFi
+++ b/YazFi
@@ -35,7 +35,6 @@ readonly IFACELIST="wl0.1 wl0.2 wl0.3 wl1.1 wl1.2 wl1.3 wl2.1 wl2.2 wl2.3"
 readonly DNSCONF="/jffs/configs/dnsmasq.conf.add"
 readonly TMPCONF="/jffs/configs/tmpdnsmasq.conf.add"
 readonly YAZFI_BLOCKDHCPFILE="/jffs/configs/$YAZFI_NAME/$YAZFI_NAME.blockdhcp"
-readonly YAZFI_ALLOWDHCPFILE="/tmp/$YAZFI_NAME.allowdhcp"
 ### End of path variables ###
 
 ### Start of firewall variables ###
@@ -1000,9 +999,9 @@ Config_Networks () {
 	DHCP_Conf save 2>/dev/null
 	
 	#Clean DHCP blocking
-	rm -f "$YAZFI_BLOCKDHCPFILE" 2>/dev/null
 	Auto_Block_DHCP delete 2>/dev/null
-	DHCP_Conf_Block delete 2>/dev/null
+	DHCP_Conf_Block delete 2>/dev/null	
+	rm -f "$YAZFI_BLOCKDHCPFILE" 2>/dev/null
 	
 	Print_Output "true" "YazFi $YAZFI_VERSION completed successfully" "$PASS"
 }

--- a/YazFi
+++ b/YazFi
@@ -236,19 +236,32 @@ Clear_Lock () {
 }
 
 Update_Version () {
-	localver=$(grep "YAZFI_VERSION=" /jffs/scripts/$YAZFI_NAME | grep -m1 -oE 'v[0-9]{1,2}([.][0-9]{1,2})([.][0-9]{1,2})')
-	/usr/sbin/curl -fsL --retry 3 "$YAZFI_REPO" | grep -qF "jackyaz" || { Print_Output "true" "404 error detected - stopping update" "$ERR"; Clear_Lock; exit 1; }
-	serverver=$(/usr/sbin/curl -fsL --retry 3 "$YAZFI_REPO" | grep "YAZFI_VERSION=" | grep -m1 -oE 'v[0-9]{1,2}([.][0-9]{1,2})([.][0-9]{1,2})')
-	if [ "$localver" != "$serverver" ]; then
-		Print_Output "true" "New version of $YAZFI_NAME available - updating to $serverver" "$PASS"
-		/usr/sbin/curl -fsL --retry 3 "$YAZFI_REPO" -o "/jffs/scripts/$YAZFI_NAME" && Print_Output "true" "YazFi successfully updated - restarting firewall to apply update"
-		chmod 0755 "/jffs/scripts/$YAZFI_NAME"
-		Clear_Lock
-		service restart_firewall >/dev/null 2>&1
-	else
-		Print_Output "true" "No new version - latest is $localver" "$WARN"
-		Clear_Lock
+	if [ -z "$1" ]; then
+		localver=$(grep "YAZFI_VERSION=" /jffs/scripts/$YAZFI_NAME | grep -m1 -oE 'v[0-9]{1,2}([.][0-9]{1,2})([.][0-9]{1,2})')
+		/usr/sbin/curl -fsL --retry 3 "$YAZFI_REPO" | grep -qF "jackyaz" || { Print_Output "true" "404 error detected - stopping update" "$ERR"; Clear_Lock; exit 1; }
+		serverver=$(/usr/sbin/curl -fsL --retry 3 "$YAZFI_REPO" | grep "YAZFI_VERSION=" | grep -m1 -oE 'v[0-9]{1,2}([.][0-9]{1,2})([.][0-9]{1,2})')
+		if [ "$localver" != "$serverver" ]; then
+			Print_Output "true" "New version of $YAZFI_NAME available - updating to $serverver" "$PASS"
+			/usr/sbin/curl -fsL --retry 3 "$YAZFI_REPO" -o "/jffs/scripts/$YAZFI_NAME" && Print_Output "true" "YazFi successfully updated - restarting firewall to apply update"
+			chmod 0755 "/jffs/scripts/$YAZFI_NAME"
+			Clear_Lock
+			service restart_firewall >/dev/null 2>&1
+		else
+			Print_Output "true" "No new version - latest is $localver" "$WARN"
+			Clear_Lock
+		fi
 	fi
+	
+	case "$1" in
+		force)
+			serverver=$(/usr/sbin/curl -fsL --retry 3 "$YAZFI_REPO" | grep "YAZFI_VERSION=" | grep -m1 -oE 'v[0-9]{1,2}([.][0-9]{1,2})([.][0-9]{1,2})')
+			Print_Output "true" "Downloading latest version ($serverver) of $YAZFI_NAME" "$PASS"
+			/usr/sbin/curl -fsL --retry 3 "$YAZFI_REPO" -o "/jffs/scripts/$YAZFI_NAME" && Print_Output "true" "YazFi successfully updated - restarting firewall to apply update"
+			chmod 0755 "/jffs/scripts/$YAZFI_NAME"
+			Clear_Lock
+			service restart_firewall >/dev/null 2>&1
+		;;
+	esac
 }
 ############################################################################
 
@@ -1023,6 +1036,14 @@ case "$1" in
 		Clear_Lock
 		exit 0
 	;;
+	forceupdate)
+		Check_Lock
+		Print_Output "true" "Welcome to YazFi $YAZFI_VERSION, a script by JackYaz"
+		sleep 1
+		Update_Version force
+		Clear_Lock
+		exit 0
+	;;
 	uninstall)
 		Check_Lock
 		Print_Output "true" "Removing YazFi..." "$PASS"
@@ -1038,13 +1059,13 @@ case "$1" in
 		exit 0
 	;;
 	bounceclients)
-		Check_Lock
 		if [ "$2" = "restart" ] && [ "$3" = "wireless" ]; then
+			Check_Lock
 			sleep 30
-			. "$YAZFI_CONF"
+			Config_Networks
 			Iface_BounceClients
+			Clear_Lock
 		fi
-		Clear_Lock
 		exit 0
 	;;
 	status)

--- a/YazFi
+++ b/YazFi
@@ -15,7 +15,7 @@ readonly YAZFI_NAME="YazFi"
 readonly YAZFI_CONF_OLD="/jffs/configs/$YAZFI_NAME.config"
 readonly YAZFI_CONF="/jffs/configs/$YAZFI_NAME/$YAZFI_NAME.config"
 readonly YAZFI_VERSION="v2.3.7"
-readonly YAZFI_BRANCH="master"
+readonly YAZFI_BRANCH="testing"
 readonly YAZFI_REPO="https://raw.githubusercontent.com/jackyaz/YazFi/""$YAZFI_BRANCH""/YazFi"
 ### End of script variables ###
 

--- a/YazFi
+++ b/YazFi
@@ -15,7 +15,7 @@ readonly YAZFI_NAME="YazFi"
 readonly YAZFI_CONF_OLD="/jffs/configs/$YAZFI_NAME.config"
 readonly YAZFI_CONF="/jffs/configs/$YAZFI_NAME/$YAZFI_NAME.config"
 readonly YAZFI_VERSION="v2.3.6"
-readonly YAZFI_BRANCH="master"
+readonly YAZFI_BRANCH="testing"
 readonly YAZFI_REPO="https://raw.githubusercontent.com/jackyaz/YazFi/""$YAZFI_BRANCH""/YazFi"
 ### End of script variables ###
 

--- a/YazFi
+++ b/YazFi
@@ -2,7 +2,7 @@
 
 ####################################################################
 ######                    YazFi by jackyaz                    ######
-######                          v2.3.6                        ######
+######                          v2.3.7                        ######
 ######            https://github.com/jackyaz/YazFi/           ######
 ######                                                        ######
 ######            Credit to @RMerlin for the original         ######
@@ -14,7 +14,7 @@
 readonly YAZFI_NAME="YazFi"
 readonly YAZFI_CONF_OLD="/jffs/configs/$YAZFI_NAME.config"
 readonly YAZFI_CONF="/jffs/configs/$YAZFI_NAME/$YAZFI_NAME.config"
-readonly YAZFI_VERSION="v2.3.6"
+readonly YAZFI_VERSION="v2.3.7"
 readonly YAZFI_BRANCH="testing"
 readonly YAZFI_REPO="https://raw.githubusercontent.com/jackyaz/YazFi/""$YAZFI_BRANCH""/YazFi"
 ### End of script variables ###
@@ -114,31 +114,53 @@ Iface_Manage () {
 	esac
 }
 
-Auto_Block_DHCP () {
+Iface_BounceClients () {
+	Print_Output "false" "De-authenticating YazFi Guest WiFi clients..." "$PASS"
+	
+	for IFACE in $IFACELIST; do
+		wl -i "$IFACE" deauthenticate  >/dev/null 2>&1
+	done
+}
+
+Auto_ServiceEvent () {
 	case $1 in
 		create)
-			if [ -f /jffs/scripts/dnsmasq.postconf ]; then
-				STARTUPLINECOUNT=$(grep -c '# '"$YAZFI_NAME"' Guest Networks' /jffs/scripts/dnsmasq.postconf)
-				STARTUPLINECOUNTEX=$(grep -cx "/jffs/scripts/$YAZFI_NAME checkdhcp"' # '"$YAZFI_NAME"' Guest Networks' /jffs/scripts/dnsmasq.postconf)
+			if [ -f /jffs/scripts/service-event ]; then
+				STARTUPLINECOUNT=$(grep -c '# '"$YAZFI_NAME"' Guest Networks' /jffs/scripts/service-event)
+				STARTUPLINECOUNTEX=$(grep -cx "/jffs/scripts/$YAZFI_NAME bounceclients"' "$1" "$2"'' # '"$YAZFI_NAME"' Guest Networks' /jffs/scripts/service-event)
 				
 				if [ "$STARTUPLINECOUNT" -gt 1 ] || { [ "$STARTUPLINECOUNTEX" -eq 0 ] && [ "$STARTUPLINECOUNT" -gt 0 ]; }; then
-					Print_Output "true" "Purging duplicate/invalid entries for $YAZFI_NAME in dnsmasq.postconf"
-					sed -i -e '/# '"$YAZFI_NAME"' Guest Networks/d' /jffs/scripts/dnsmasq.postconf
+					Print_Output "true" "Purging duplicate/invalid entries for $YAZFI_NAME in service-event"
+					sed -i -e '/# '"$YAZFI_NAME"' Guest Networks/d' /jffs/scripts/service-event
 				fi
 				
 				if [ "$STARTUPLINECOUNTEX" -eq 0 ]; then
-					Print_Output "true" "Adding $YAZFI_NAME to dnsmasq.postconf"
-					echo "" >> /jffs/scripts/dnsmasq.postconf
-					echo "/jffs/scripts/$YAZFI_NAME checkdhcp"' # '"$YAZFI_NAME"' Guest Networks' >> /jffs/scripts/dnsmasq.postconf
+					Print_Output "true" "Adding $YAZFI_NAME to service-event"
+					echo "" >> /jffs/scripts/service-event
+					echo "/jffs/scripts/$YAZFI_NAME bounceclients"' "$1" "$2"'' # '"$YAZFI_NAME"' Guest Networks' >> /jffs/scripts/service-event
 				fi
 			else
-				Print_Output "true" "dnsmasq.postconf doesn't exist, creating"
-				echo "#!/bin/sh" > /jffs/scripts/dnsmasq.postconf
-				echo "" >> /jffs/scripts/dnsmasq.postconf
-				echo "/jffs/scripts/$YAZFI_NAME checkdhcp"' # '"$YAZFI_NAME"' Guest Networks' >> /jffs/scripts/dnsmasq.postconf
-				chmod 0755 /jffs/scripts/dnsmasq.postconf
+				Print_Output "true" "service-event doesn't exist, creating"
+				echo "#!/bin/sh" > /jffs/scripts/service-event
+				echo "" >> /jffs/scripts/service-event
+				echo "/jffs/scripts/$YAZFI_NAME bounceclients"' "$1" "$2"'' # '"$YAZFI_NAME"' Guest Networks' >> /jffs/scripts/service-event
+				chmod 0755 /jffs/scripts/service-event
 			fi
 		;;
+		delete)
+			if [ -f /jffs/scripts/service-event ]; then
+				STARTUPLINECOUNT=$(grep -c '# '"$YAZFI_NAME"' Guest Networks' /jffs/scripts/service-event)
+				
+				if [ "$STARTUPLINECOUNT" -gt 0 ]; then
+					sed -i -e '/# '"$YAZFI_NAME"' Guest Networks/d' /jffs/scripts/service-event
+				fi
+			fi
+		;;
+	esac
+}
+
+Auto_Block_DHCP () {
+	case $1 in
 		delete)
 			if [ -f /jffs/scripts/dnsmasq.postconf ]; then
 				STARTUPLINECOUNT=$(grep -c '# '"$YAZFI_NAME"' Guest Networks' /jffs/scripts/dnsmasq.postconf)
@@ -815,24 +837,8 @@ Routing_NVRAM () {
 	esac
 }
 
-DHCP_Unblock () {
-	if [ ! -f "$YAZFI_ALLOWDHCPFILE" ]; then
-		echo "$$" > "$YAZFI_ALLOWDHCPFILE"
-		sleep 5
-		service restart_dnsmasq >/dev/null 2>&1
-	fi
-	return 0
-}
-
 DHCP_Conf_Block () {
 	case $1 in
-		create)
-			DHCPBLOCK_BR0=$(grep -c '# '"$YAZFI_NAME"' Guest Networks' $DNSCONF)
-			
-			if [ "$DHCPBLOCK_BR0" -eq 0 ]; then
-				printf "no-dhcp-interface=br0 # %s Guest Networks\\n" "$YAZFI_NAME" >> $DNSCONF
-			fi
-		;;
 		delete)
 			DHCPBLOCK_BR0=$(grep -c '# '"$YAZFI_NAME"' Guest Networks' $DNSCONF)
 			
@@ -853,12 +859,7 @@ DHCP_Conf () {
 			fi
 		;;
 		create)
-			CONFSTRING=""
-			if [ "$BLOCKDHCP" = "true" ]; then
-				CONFSTRING="interface=$2||||no-dhcp-interface=$2||||dhcp-range=$2,$(eval echo '$'"$(Get_Iface_Var "$2")""_IPADDR" | cut -f1-3 -d".").$(eval echo '$'"$(Get_Iface_Var "$2")""_DHCPSTART"),$(eval echo '$'"$(Get_Iface_Var "$2")""_IPADDR" | cut -f1-3 -d".").$(eval echo '$'"$(Get_Iface_Var "$2")""_DHCPEND"),255.255.255.0,43200s||||dhcp-option=$2,3,$(eval echo '$'"$(Get_Iface_Var "$2")""_IPADDR" | cut -f1-3 -d".").1||||dhcp-option=$2,6,$(eval echo '$'"$(Get_Iface_Var "$2")""_DNS1"),$(eval echo '$'"$(Get_Iface_Var "$2")""_DNS2")"
-			else
-				CONFSTRING="interface=$2||||dhcp-range=$2,$(eval echo '$'"$(Get_Iface_Var "$2")""_IPADDR" | cut -f1-3 -d".").$(eval echo '$'"$(Get_Iface_Var "$2")""_DHCPSTART"),$(eval echo '$'"$(Get_Iface_Var "$2")""_IPADDR" | cut -f1-3 -d".").$(eval echo '$'"$(Get_Iface_Var "$2")""_DHCPEND"),255.255.255.0,43200s||||dhcp-option=$2,3,$(eval echo '$'"$(Get_Iface_Var "$2")""_IPADDR" | cut -f1-3 -d".").1||||dhcp-option=$2,6,$(eval echo '$'"$(Get_Iface_Var "$2")""_DNS1"),$(eval echo '$'"$(Get_Iface_Var "$2")""_DNS2")"
-			fi
+			CONFSTRING="interface=$2||||dhcp-range=$2,$(eval echo '$'"$(Get_Iface_Var "$2")""_IPADDR" | cut -f1-3 -d".").$(eval echo '$'"$(Get_Iface_Var "$2")""_DHCPSTART"),$(eval echo '$'"$(Get_Iface_Var "$2")""_IPADDR" | cut -f1-3 -d".").$(eval echo '$'"$(Get_Iface_Var "$2")""_DHCPEND"),255.255.255.0,43200s||||dhcp-option=$2,3,$(eval echo '$'"$(Get_Iface_Var "$2")""_IPADDR" | cut -f1-3 -d".").1||||dhcp-option=$2,6,$(eval echo '$'"$(Get_Iface_Var "$2")""_DNS1"),$(eval echo '$'"$(Get_Iface_Var "$2")""_DNS2")"
 			BEGIN="### Start of script-generated configuration for interface $2 ###"
 			END="### End of script-generated configuration for interface $2 ###"
 			if grep -q "### Start of script-generated configuration for interface $2 ###" $TMPCONF; then
@@ -899,6 +900,8 @@ DHCP_Conf () {
 				cp $TMPCONF $DNSCONF
 				service restart_dnsmasq >/dev/null 2>&1
 				Print_Output "true" "DHCP configuration updated"
+				sleep 2
+				Iface_BounceClients 2>/dev/null
 			fi
 			
 			rm -f $TMPCONF
@@ -919,11 +922,7 @@ Config_Networks () {
 	. $YAZFI_CONF
 	
 	Auto_Startup create 2>/dev/null
-	
-	if [ "$BLOCKDHCP" = "true" ]; then
-		DHCP_Conf_Block create 2>/dev/null
-		Auto_Block_DHCP create 2>/dev/null
-	fi
+	Auto_ServiceEvent create 2>/dev/null
 	
 	DHCP_Conf initialise 2>/dev/null
 	
@@ -987,11 +986,7 @@ Config_Networks () {
 	
 	DHCP_Conf save 2>/dev/null
 	
-	if [ "$BLOCKDHCP" = "true" ]; then
-		DHCP_Unblock
-	fi
-	
-	Clear_Lock
+	rm -f "$YAZFI_BLOCKDHCPFILE" 2>/dev/null
 	
 	Print_Output "true" "YazFi $YAZFI_VERSION completed successfully" "$PASS"
 }
@@ -1028,53 +1023,27 @@ case "$1" in
 		Clear_Lock
 		exit 0
 	;;
-	checkdhcp)
-		. "$YAZFI_CONF"
-		if [ -f "$YAZFI_ALLOWDHCPFILE" ]; then
-			for IFACE in $IFACELIST; do
-				if [ "$(eval echo '$'"$(Get_Iface_Var "$IFACE")""_ENABLED")" = "true" ]; then
-					sed -i "/$(echo "no-dhcp-interface=""$IFACE" | sed 's/[]\/$*.^|[]/\\&/g')/d" "/etc/dnsmasq.conf"
-				fi
-			done
-			sed -i -e '/# '"$YAZFI_NAME"' Guest Networks/d' "/etc/dnsmasq.conf"
-		fi
-		exit 0
-	;;
-	blockdhcp)
-		Check_Lock
-		Print_Output "true" "Preventing dnsmasq from providing DHCP" "$PASS"
-		echo "$$" > "$YAZFI_BLOCKDHCPFILE"
-		Auto_Block_DHCP create 2>/dev/null
-		DHCP_Conf_Block create 2>/dev/null
-		BLOCKDHCP="true"
-		Config_Networks
-		Clear_Lock
-		exit 0
-	;;
-	unblockdhcp)
-		Check_Lock
-		Print_Output "true" "Allowing dnsmasq to provide DHCP" "$PASS"
-		rm -f "$YAZFI_BLOCKDHCPFILE" 2>/dev/null
-		rm -f "$YAZFI_ALLOWDHCPFILE" 2>/dev/null
-		Auto_Block_DHCP delete 2>/dev/null
-		DHCP_Conf_Block delete 2>/dev/null
-		BLOCKDHCP="false"
-		Config_Networks
-		Clear_Lock
-		exit 0
-	;;
 	uninstall)
 		Check_Lock
 		Print_Output "true" "Removing YazFi..." "$PASS"
 		Auto_Startup delete 2>/dev/null
-		Auto_Block_DHCP delete 2>/dev/null
+		Auto_ServiceEvent delete 2>/dev/null
 		Routing_NVRAM deleteall 2>/dev/null
 		Routing_FWNAT deleteall 2>/dev/null
 		Routing_RPDB deleteall 2>/dev/null
 		Firewall_Chains deleteall 2>/dev/null
 		Iface_Manage deleteall 2>/dev/null
 		DHCP_Conf deleteall 2>/dev/null
-		DHCP_Conf_Block delete 2>/dev/null
+		Clear_Lock
+		exit 0
+	;;
+	bounceclients)
+		Check_Lock
+		if [ "$2" = "restart" ] && [ "$3" = "wireless" ]; then
+			sleep 30
+			. "$YAZFI_CONF"
+			Iface_BounceClients
+		fi
 		Clear_Lock
 		exit 0
 	;;

--- a/YazFi.shellcheck
+++ b/YazFi.shellcheck
@@ -126,7 +126,7 @@ Auto_ServiceEvent () {
 		create)
 			if [ -f /jffs/scripts/service-event ]; then
 				STARTUPLINECOUNT=$(grep -c '# '"$YAZFI_NAME"' Guest Networks' /jffs/scripts/service-event)
-				STARTUPLINECOUNTEX=$(grep -cx "/jffs/scripts/$YAZFI_NAME bounceclients"' "$1" "$2"'' # '"$YAZFI_NAME"' Guest Networks' /jffs/scripts/service-event)
+				STARTUPLINECOUNTEX=$(grep -cx "/jffs/scripts/$YAZFI_NAME bounceclients"' "$1" "$2" &'' # '"$YAZFI_NAME"' Guest Networks' /jffs/scripts/service-event)
 				
 				if [ "$STARTUPLINECOUNT" -gt 1 ] || { [ "$STARTUPLINECOUNTEX" -eq 0 ] && [ "$STARTUPLINECOUNT" -gt 0 ]; }; then
 					Print_Output "true" "Purging duplicate/invalid entries for $YAZFI_NAME in service-event"
@@ -136,13 +136,13 @@ Auto_ServiceEvent () {
 				if [ "$STARTUPLINECOUNTEX" -eq 0 ]; then
 					Print_Output "true" "Adding $YAZFI_NAME to service-event"
 					echo "" >> /jffs/scripts/service-event
-					echo "/jffs/scripts/$YAZFI_NAME bounceclients"' "$1" "$2"'' # '"$YAZFI_NAME"' Guest Networks' >> /jffs/scripts/service-event
+					echo "/jffs/scripts/$YAZFI_NAME bounceclients"' "$1" "$2" &'' # '"$YAZFI_NAME"' Guest Networks' >> /jffs/scripts/service-event
 				fi
 			else
 				Print_Output "true" "service-event doesn't exist, creating"
 				echo "#!/bin/sh" > /jffs/scripts/service-event
 				echo "" >> /jffs/scripts/service-event
-				echo "/jffs/scripts/$YAZFI_NAME bounceclients"' "$1" "$2"'' # '"$YAZFI_NAME"' Guest Networks' >> /jffs/scripts/service-event
+				echo "/jffs/scripts/$YAZFI_NAME bounceclients"' "$1" "$2" &'' # '"$YAZFI_NAME"' Guest Networks' >> /jffs/scripts/service-event
 				chmod 0755 /jffs/scripts/service-event
 			fi
 		;;

--- a/YazFi.shellcheck
+++ b/YazFi.shellcheck
@@ -115,7 +115,7 @@ Iface_Manage () {
 }
 
 Iface_BounceClients () {
-	Print_Output "false" "De-authenticating YazFi Guest WiFi clients..." "$PASS"
+	Print_Output "true" "Forcing YazFi Guest WiFi clients to reauthenticate" "$PASS"
 	
 	for IFACE in $IFACELIST; do
 		wl -i "$IFACE" deauthenticate  >/dev/null 2>&1
@@ -1059,8 +1059,13 @@ case "$1" in
 		exit 0
 	;;
 	bounceclients)
-		if [ "$2" = "restart" ] && [ "$3" = "wireless" ]; then
+		if [ -z "$2" ] && [ -z "$3" ]; then
 			Check_Lock
+			Iface_BounceClients
+			Clear_Lock
+		elif [ "$2" = "restart" ] && [ "$3" = "wireless" ]; then
+			Check_Lock
+			Print_Output "true" "Wireless restarted - sleeping 30s before running YazFi" "$PASS"
 			sleep 30
 			Config_Networks
 			Iface_BounceClients

--- a/YazFi.shellcheck
+++ b/YazFi.shellcheck
@@ -15,7 +15,7 @@ readonly YAZFI_NAME="YazFi"
 readonly YAZFI_CONF_OLD="/jffs/configs/$YAZFI_NAME.config"
 readonly YAZFI_CONF="/jffs/configs/$YAZFI_NAME/$YAZFI_NAME.config"
 readonly YAZFI_VERSION="v2.3.7"
-readonly YAZFI_BRANCH="testing"
+readonly YAZFI_BRANCH="master"
 readonly YAZFI_REPO="https://raw.githubusercontent.com/jackyaz/YazFi/""$YAZFI_BRANCH""/YazFi"
 ### End of script variables ###
 

--- a/YazFi.shellcheck
+++ b/YazFi.shellcheck
@@ -999,7 +999,10 @@ Config_Networks () {
 	
 	DHCP_Conf save 2>/dev/null
 	
+	#Clean DHCP blocking
 	rm -f "$YAZFI_BLOCKDHCPFILE" 2>/dev/null
+	Auto_Block_DHCP delete 2>/dev/null
+	DHCP_Conf_Block delete 2>/dev/null
 	
 	Print_Output "true" "YazFi $YAZFI_VERSION completed successfully" "$PASS"
 }

--- a/YazFi.shellcheck
+++ b/YazFi.shellcheck
@@ -999,9 +999,12 @@ Config_Networks () {
 	DHCP_Conf save 2>/dev/null
 	
 	#Clean DHCP blocking
-	Auto_Block_DHCP delete 2>/dev/null
-	DHCP_Conf_Block delete 2>/dev/null	
-	rm -f "$YAZFI_BLOCKDHCPFILE" 2>/dev/null
+	if [ "$BLOCKDHCP" = "true" ]; then
+		Auto_Block_DHCP delete 2>/dev/null
+		DHCP_Conf_Block delete 2>/dev/null
+		rm -f "$YAZFI_BLOCKDHCPFILE" 2>/dev/null
+		service restart_dnsmasq >/dev/null 2>&1
+	fi
 	
 	Print_Output "true" "YazFi $YAZFI_VERSION completed successfully" "$PASS"
 }

--- a/YazFi.shellcheck
+++ b/YazFi.shellcheck
@@ -35,7 +35,6 @@ readonly IFACELIST="wl0.1 wl0.2 wl0.3 wl1.1 wl1.2 wl1.3 wl2.1 wl2.2 wl2.3"
 readonly DNSCONF="/jffs/configs/dnsmasq.conf.add"
 readonly TMPCONF="/jffs/configs/tmpdnsmasq.conf.add"
 readonly YAZFI_BLOCKDHCPFILE="/jffs/configs/$YAZFI_NAME/$YAZFI_NAME.blockdhcp"
-readonly YAZFI_ALLOWDHCPFILE="/tmp/$YAZFI_NAME.allowdhcp"
 ### End of path variables ###
 
 ### Start of firewall variables ###
@@ -1000,9 +999,9 @@ Config_Networks () {
 	DHCP_Conf save 2>/dev/null
 	
 	#Clean DHCP blocking
-	rm -f "$YAZFI_BLOCKDHCPFILE" 2>/dev/null
 	Auto_Block_DHCP delete 2>/dev/null
-	DHCP_Conf_Block delete 2>/dev/null
+	DHCP_Conf_Block delete 2>/dev/null	
+	rm -f "$YAZFI_BLOCKDHCPFILE" 2>/dev/null
 	
 	Print_Output "true" "YazFi $YAZFI_VERSION completed successfully" "$PASS"
 }

--- a/YazFi.shellcheck
+++ b/YazFi.shellcheck
@@ -236,19 +236,32 @@ Clear_Lock () {
 }
 
 Update_Version () {
-	localver=$(grep "YAZFI_VERSION=" /jffs/scripts/$YAZFI_NAME | grep -m1 -oE 'v[0-9]{1,2}([.][0-9]{1,2})([.][0-9]{1,2})')
-	/usr/sbin/curl -fsL --retry 3 "$YAZFI_REPO" | grep -qF "jackyaz" || { Print_Output "true" "404 error detected - stopping update" "$ERR"; Clear_Lock; exit 1; }
-	serverver=$(/usr/sbin/curl -fsL --retry 3 "$YAZFI_REPO" | grep "YAZFI_VERSION=" | grep -m1 -oE 'v[0-9]{1,2}([.][0-9]{1,2})([.][0-9]{1,2})')
-	if [ "$localver" != "$serverver" ]; then
-		Print_Output "true" "New version of $YAZFI_NAME available - updating to $serverver" "$PASS"
-		/usr/sbin/curl -fsL --retry 3 "$YAZFI_REPO" -o "/jffs/scripts/$YAZFI_NAME" && Print_Output "true" "YazFi successfully updated - restarting firewall to apply update"
-		chmod 0755 "/jffs/scripts/$YAZFI_NAME"
-		Clear_Lock
-		service restart_firewall >/dev/null 2>&1
-	else
-		Print_Output "true" "No new version - latest is $localver" "$WARN"
-		Clear_Lock
+	if [ -z "$1" ]; then
+		localver=$(grep "YAZFI_VERSION=" /jffs/scripts/$YAZFI_NAME | grep -m1 -oE 'v[0-9]{1,2}([.][0-9]{1,2})([.][0-9]{1,2})')
+		/usr/sbin/curl -fsL --retry 3 "$YAZFI_REPO" | grep -qF "jackyaz" || { Print_Output "true" "404 error detected - stopping update" "$ERR"; Clear_Lock; exit 1; }
+		serverver=$(/usr/sbin/curl -fsL --retry 3 "$YAZFI_REPO" | grep "YAZFI_VERSION=" | grep -m1 -oE 'v[0-9]{1,2}([.][0-9]{1,2})([.][0-9]{1,2})')
+		if [ "$localver" != "$serverver" ]; then
+			Print_Output "true" "New version of $YAZFI_NAME available - updating to $serverver" "$PASS"
+			/usr/sbin/curl -fsL --retry 3 "$YAZFI_REPO" -o "/jffs/scripts/$YAZFI_NAME" && Print_Output "true" "YazFi successfully updated - restarting firewall to apply update"
+			chmod 0755 "/jffs/scripts/$YAZFI_NAME"
+			Clear_Lock
+			service restart_firewall >/dev/null 2>&1
+		else
+			Print_Output "true" "No new version - latest is $localver" "$WARN"
+			Clear_Lock
+		fi
 	fi
+	
+	case "$1" in
+		force)
+			serverver=$(/usr/sbin/curl -fsL --retry 3 "$YAZFI_REPO" | grep "YAZFI_VERSION=" | grep -m1 -oE 'v[0-9]{1,2}([.][0-9]{1,2})([.][0-9]{1,2})')
+			Print_Output "true" "Downloading latest version ($serverver) of $YAZFI_NAME" "$PASS"
+			/usr/sbin/curl -fsL --retry 3 "$YAZFI_REPO" -o "/jffs/scripts/$YAZFI_NAME" && Print_Output "true" "YazFi successfully updated - restarting firewall to apply update"
+			chmod 0755 "/jffs/scripts/$YAZFI_NAME"
+			Clear_Lock
+			service restart_firewall >/dev/null 2>&1
+		;;
+	esac
 }
 ############################################################################
 
@@ -1023,6 +1036,14 @@ case "$1" in
 		Clear_Lock
 		exit 0
 	;;
+	forceupdate)
+		Check_Lock
+		Print_Output "true" "Welcome to YazFi $YAZFI_VERSION, a script by JackYaz"
+		sleep 1
+		Update_Version force
+		Clear_Lock
+		exit 0
+	;;
 	uninstall)
 		Check_Lock
 		Print_Output "true" "Removing YazFi..." "$PASS"
@@ -1038,13 +1059,13 @@ case "$1" in
 		exit 0
 	;;
 	bounceclients)
-		Check_Lock
 		if [ "$2" = "restart" ] && [ "$3" = "wireless" ]; then
+			Check_Lock
 			sleep 30
-			. "$YAZFI_CONF"
+			Config_Networks
 			Iface_BounceClients
+			Clear_Lock
 		fi
-		Clear_Lock
 		exit 0
 	;;
 	status)

--- a/YazFi.shellcheck
+++ b/YazFi.shellcheck
@@ -15,7 +15,7 @@ readonly YAZFI_NAME="YazFi"
 readonly YAZFI_CONF_OLD="/jffs/configs/$YAZFI_NAME.config"
 readonly YAZFI_CONF="/jffs/configs/$YAZFI_NAME/$YAZFI_NAME.config"
 readonly YAZFI_VERSION="v2.3.7"
-readonly YAZFI_BRANCH="master"
+readonly YAZFI_BRANCH="testing"
 readonly YAZFI_REPO="https://raw.githubusercontent.com/jackyaz/YazFi/""$YAZFI_BRANCH""/YazFi"
 ### End of script variables ###
 

--- a/YazFi.shellcheck
+++ b/YazFi.shellcheck
@@ -15,7 +15,7 @@ readonly YAZFI_NAME="YazFi"
 readonly YAZFI_CONF_OLD="/jffs/configs/$YAZFI_NAME.config"
 readonly YAZFI_CONF="/jffs/configs/$YAZFI_NAME/$YAZFI_NAME.config"
 readonly YAZFI_VERSION="v2.3.6"
-readonly YAZFI_BRANCH="master"
+readonly YAZFI_BRANCH="testing"
 readonly YAZFI_REPO="https://raw.githubusercontent.com/jackyaz/YazFi/""$YAZFI_BRANCH""/YazFi"
 ### End of script variables ###
 

--- a/YazFi.shellcheck
+++ b/YazFi.shellcheck
@@ -2,7 +2,7 @@
 
 ####################################################################
 ######                    YazFi by jackyaz                    ######
-######                          v2.3.6                        ######
+######                          v2.3.7                        ######
 ######            https://github.com/jackyaz/YazFi/           ######
 ######                                                        ######
 ######            Credit to @RMerlin for the original         ######
@@ -14,7 +14,7 @@
 readonly YAZFI_NAME="YazFi"
 readonly YAZFI_CONF_OLD="/jffs/configs/$YAZFI_NAME.config"
 readonly YAZFI_CONF="/jffs/configs/$YAZFI_NAME/$YAZFI_NAME.config"
-readonly YAZFI_VERSION="v2.3.6"
+readonly YAZFI_VERSION="v2.3.7"
 readonly YAZFI_BRANCH="testing"
 readonly YAZFI_REPO="https://raw.githubusercontent.com/jackyaz/YazFi/""$YAZFI_BRANCH""/YazFi"
 ### End of script variables ###
@@ -114,31 +114,53 @@ Iface_Manage () {
 	esac
 }
 
-Auto_Block_DHCP () {
+Iface_BounceClients () {
+	Print_Output "false" "De-authenticating YazFi Guest WiFi clients..." "$PASS"
+	
+	for IFACE in $IFACELIST; do
+		wl -i "$IFACE" deauthenticate  >/dev/null 2>&1
+	done
+}
+
+Auto_ServiceEvent () {
 	case $1 in
 		create)
-			if [ -f /jffs/scripts/dnsmasq.postconf ]; then
-				STARTUPLINECOUNT=$(grep -c '# '"$YAZFI_NAME"' Guest Networks' /jffs/scripts/dnsmasq.postconf)
-				STARTUPLINECOUNTEX=$(grep -cx "/jffs/scripts/$YAZFI_NAME checkdhcp"' # '"$YAZFI_NAME"' Guest Networks' /jffs/scripts/dnsmasq.postconf)
+			if [ -f /jffs/scripts/service-event ]; then
+				STARTUPLINECOUNT=$(grep -c '# '"$YAZFI_NAME"' Guest Networks' /jffs/scripts/service-event)
+				STARTUPLINECOUNTEX=$(grep -cx "/jffs/scripts/$YAZFI_NAME bounceclients"' "$1" "$2"'' # '"$YAZFI_NAME"' Guest Networks' /jffs/scripts/service-event)
 				
 				if [ "$STARTUPLINECOUNT" -gt 1 ] || { [ "$STARTUPLINECOUNTEX" -eq 0 ] && [ "$STARTUPLINECOUNT" -gt 0 ]; }; then
-					Print_Output "true" "Purging duplicate/invalid entries for $YAZFI_NAME in dnsmasq.postconf"
-					sed -i -e '/# '"$YAZFI_NAME"' Guest Networks/d' /jffs/scripts/dnsmasq.postconf
+					Print_Output "true" "Purging duplicate/invalid entries for $YAZFI_NAME in service-event"
+					sed -i -e '/# '"$YAZFI_NAME"' Guest Networks/d' /jffs/scripts/service-event
 				fi
 				
 				if [ "$STARTUPLINECOUNTEX" -eq 0 ]; then
-					Print_Output "true" "Adding $YAZFI_NAME to dnsmasq.postconf"
-					echo "" >> /jffs/scripts/dnsmasq.postconf
-					echo "/jffs/scripts/$YAZFI_NAME checkdhcp"' # '"$YAZFI_NAME"' Guest Networks' >> /jffs/scripts/dnsmasq.postconf
+					Print_Output "true" "Adding $YAZFI_NAME to service-event"
+					echo "" >> /jffs/scripts/service-event
+					echo "/jffs/scripts/$YAZFI_NAME bounceclients"' "$1" "$2"'' # '"$YAZFI_NAME"' Guest Networks' >> /jffs/scripts/service-event
 				fi
 			else
-				Print_Output "true" "dnsmasq.postconf doesn't exist, creating"
-				echo "#!/bin/sh" > /jffs/scripts/dnsmasq.postconf
-				echo "" >> /jffs/scripts/dnsmasq.postconf
-				echo "/jffs/scripts/$YAZFI_NAME checkdhcp"' # '"$YAZFI_NAME"' Guest Networks' >> /jffs/scripts/dnsmasq.postconf
-				chmod 0755 /jffs/scripts/dnsmasq.postconf
+				Print_Output "true" "service-event doesn't exist, creating"
+				echo "#!/bin/sh" > /jffs/scripts/service-event
+				echo "" >> /jffs/scripts/service-event
+				echo "/jffs/scripts/$YAZFI_NAME bounceclients"' "$1" "$2"'' # '"$YAZFI_NAME"' Guest Networks' >> /jffs/scripts/service-event
+				chmod 0755 /jffs/scripts/service-event
 			fi
 		;;
+		delete)
+			if [ -f /jffs/scripts/service-event ]; then
+				STARTUPLINECOUNT=$(grep -c '# '"$YAZFI_NAME"' Guest Networks' /jffs/scripts/service-event)
+				
+				if [ "$STARTUPLINECOUNT" -gt 0 ]; then
+					sed -i -e '/# '"$YAZFI_NAME"' Guest Networks/d' /jffs/scripts/service-event
+				fi
+			fi
+		;;
+	esac
+}
+
+Auto_Block_DHCP () {
+	case $1 in
 		delete)
 			if [ -f /jffs/scripts/dnsmasq.postconf ]; then
 				STARTUPLINECOUNT=$(grep -c '# '"$YAZFI_NAME"' Guest Networks' /jffs/scripts/dnsmasq.postconf)
@@ -815,24 +837,8 @@ Routing_NVRAM () {
 	esac
 }
 
-DHCP_Unblock () {
-	if [ ! -f "$YAZFI_ALLOWDHCPFILE" ]; then
-		echo "$$" > "$YAZFI_ALLOWDHCPFILE"
-		sleep 5
-		service restart_dnsmasq >/dev/null 2>&1
-	fi
-	return 0
-}
-
 DHCP_Conf_Block () {
 	case $1 in
-		create)
-			DHCPBLOCK_BR0=$(grep -c '# '"$YAZFI_NAME"' Guest Networks' $DNSCONF)
-			
-			if [ "$DHCPBLOCK_BR0" -eq 0 ]; then
-				printf "no-dhcp-interface=br0 # %s Guest Networks\\n" "$YAZFI_NAME" >> $DNSCONF
-			fi
-		;;
 		delete)
 			DHCPBLOCK_BR0=$(grep -c '# '"$YAZFI_NAME"' Guest Networks' $DNSCONF)
 			
@@ -853,12 +859,7 @@ DHCP_Conf () {
 			fi
 		;;
 		create)
-			CONFSTRING=""
-			if [ "$BLOCKDHCP" = "true" ]; then
-				CONFSTRING="interface=$2||||no-dhcp-interface=$2||||dhcp-range=$2,$(eval echo '$'"$(Get_Iface_Var "$2")""_IPADDR" | cut -f1-3 -d".").$(eval echo '$'"$(Get_Iface_Var "$2")""_DHCPSTART"),$(eval echo '$'"$(Get_Iface_Var "$2")""_IPADDR" | cut -f1-3 -d".").$(eval echo '$'"$(Get_Iface_Var "$2")""_DHCPEND"),255.255.255.0,43200s||||dhcp-option=$2,3,$(eval echo '$'"$(Get_Iface_Var "$2")""_IPADDR" | cut -f1-3 -d".").1||||dhcp-option=$2,6,$(eval echo '$'"$(Get_Iface_Var "$2")""_DNS1"),$(eval echo '$'"$(Get_Iface_Var "$2")""_DNS2")"
-			else
-				CONFSTRING="interface=$2||||dhcp-range=$2,$(eval echo '$'"$(Get_Iface_Var "$2")""_IPADDR" | cut -f1-3 -d".").$(eval echo '$'"$(Get_Iface_Var "$2")""_DHCPSTART"),$(eval echo '$'"$(Get_Iface_Var "$2")""_IPADDR" | cut -f1-3 -d".").$(eval echo '$'"$(Get_Iface_Var "$2")""_DHCPEND"),255.255.255.0,43200s||||dhcp-option=$2,3,$(eval echo '$'"$(Get_Iface_Var "$2")""_IPADDR" | cut -f1-3 -d".").1||||dhcp-option=$2,6,$(eval echo '$'"$(Get_Iface_Var "$2")""_DNS1"),$(eval echo '$'"$(Get_Iface_Var "$2")""_DNS2")"
-			fi
+			CONFSTRING="interface=$2||||dhcp-range=$2,$(eval echo '$'"$(Get_Iface_Var "$2")""_IPADDR" | cut -f1-3 -d".").$(eval echo '$'"$(Get_Iface_Var "$2")""_DHCPSTART"),$(eval echo '$'"$(Get_Iface_Var "$2")""_IPADDR" | cut -f1-3 -d".").$(eval echo '$'"$(Get_Iface_Var "$2")""_DHCPEND"),255.255.255.0,43200s||||dhcp-option=$2,3,$(eval echo '$'"$(Get_Iface_Var "$2")""_IPADDR" | cut -f1-3 -d".").1||||dhcp-option=$2,6,$(eval echo '$'"$(Get_Iface_Var "$2")""_DNS1"),$(eval echo '$'"$(Get_Iface_Var "$2")""_DNS2")"
 			BEGIN="### Start of script-generated configuration for interface $2 ###"
 			END="### End of script-generated configuration for interface $2 ###"
 			if grep -q "### Start of script-generated configuration for interface $2 ###" $TMPCONF; then
@@ -899,6 +900,8 @@ DHCP_Conf () {
 				cp $TMPCONF $DNSCONF
 				service restart_dnsmasq >/dev/null 2>&1
 				Print_Output "true" "DHCP configuration updated"
+				sleep 2
+				Iface_BounceClients 2>/dev/null
 			fi
 			
 			rm -f $TMPCONF
@@ -919,11 +922,7 @@ Config_Networks () {
 	. $YAZFI_CONF
 	
 	Auto_Startup create 2>/dev/null
-	
-	if [ "$BLOCKDHCP" = "true" ]; then
-		DHCP_Conf_Block create 2>/dev/null
-		Auto_Block_DHCP create 2>/dev/null
-	fi
+	Auto_ServiceEvent create 2>/dev/null
 	
 	DHCP_Conf initialise 2>/dev/null
 	
@@ -987,11 +986,7 @@ Config_Networks () {
 	
 	DHCP_Conf save 2>/dev/null
 	
-	if [ "$BLOCKDHCP" = "true" ]; then
-		DHCP_Unblock
-	fi
-	
-	Clear_Lock
+	rm -f "$YAZFI_BLOCKDHCPFILE" 2>/dev/null
 	
 	Print_Output "true" "YazFi $YAZFI_VERSION completed successfully" "$PASS"
 }
@@ -1028,53 +1023,27 @@ case "$1" in
 		Clear_Lock
 		exit 0
 	;;
-	checkdhcp)
-		. "$YAZFI_CONF"
-		if [ -f "$YAZFI_ALLOWDHCPFILE" ]; then
-			for IFACE in $IFACELIST; do
-				if [ "$(eval echo '$'"$(Get_Iface_Var "$IFACE")""_ENABLED")" = "true" ]; then
-					sed -i "/$(echo "no-dhcp-interface=""$IFACE" | sed 's/[]\/$*.^|[]/\\&/g')/d" "/etc/dnsmasq.conf"
-				fi
-			done
-			sed -i -e '/# '"$YAZFI_NAME"' Guest Networks/d' "/etc/dnsmasq.conf"
-		fi
-		exit 0
-	;;
-	blockdhcp)
-		Check_Lock
-		Print_Output "true" "Preventing dnsmasq from providing DHCP" "$PASS"
-		echo "$$" > "$YAZFI_BLOCKDHCPFILE"
-		Auto_Block_DHCP create 2>/dev/null
-		DHCP_Conf_Block create 2>/dev/null
-		BLOCKDHCP="true"
-		Config_Networks
-		Clear_Lock
-		exit 0
-	;;
-	unblockdhcp)
-		Check_Lock
-		Print_Output "true" "Allowing dnsmasq to provide DHCP" "$PASS"
-		rm -f "$YAZFI_BLOCKDHCPFILE" 2>/dev/null
-		rm -f "$YAZFI_ALLOWDHCPFILE" 2>/dev/null
-		Auto_Block_DHCP delete 2>/dev/null
-		DHCP_Conf_Block delete 2>/dev/null
-		BLOCKDHCP="false"
-		Config_Networks
-		Clear_Lock
-		exit 0
-	;;
 	uninstall)
 		Check_Lock
 		Print_Output "true" "Removing YazFi..." "$PASS"
 		Auto_Startup delete 2>/dev/null
-		Auto_Block_DHCP delete 2>/dev/null
+		Auto_ServiceEvent delete 2>/dev/null
 		Routing_NVRAM deleteall 2>/dev/null
 		Routing_FWNAT deleteall 2>/dev/null
 		Routing_RPDB deleteall 2>/dev/null
 		Firewall_Chains deleteall 2>/dev/null
 		Iface_Manage deleteall 2>/dev/null
 		DHCP_Conf deleteall 2>/dev/null
-		DHCP_Conf_Block delete 2>/dev/null
+		Clear_Lock
+		exit 0
+	;;
+	bounceclients)
+		Check_Lock
+		if [ "$2" = "restart" ] && [ "$3" = "wireless" ]; then
+			sleep 30
+			. "$YAZFI_CONF"
+			Iface_BounceClients
+		fi
 		Clear_Lock
 		exit 0
 	;;


### PR DESCRIPTION
- Adds bounceclients command - force Guest WiFi clients to re-authenticate
- Adds forceupdate command - force a re-download of latest YazFi from source
- Incorporate above into YazFi running, so clients should always get the correct IP/routing
- Adopt use of service-event to catch any restarts of the wireless service (e.g. editing settings in the router GUI). This means there is now a minimum f/w requirement, and unfortunately support for the 380.XX branch is no longer possible
- Remove blockdhcp - superceded by bounceclients