### PR TITLE
v3.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/a2cf9bdec17b4b6f9b6e113f802be694)](https://app.codacy.com/app/jackyaz/YazFi?utm_source=github.com&utm_medium=referral&utm_content=jackyaz/YazFi&utm_campaign=Badge_Grade_Dashboard)
 [![Build Status](https://travis-ci.com/jackyaz/YazFi.svg?branch=master)](https://travis-ci.com/jackyaz/YazFi)
 
-## v3.2.3
-### Updated on 2020-01-24
+## v3.3.0
+### Updated on 2020-01-30
 ## About
 Feature expansion of guest WiFi networks on AsusWRT-Merlin, including, but not limited to:
 

--- a/README.md
+++ b/README.md
@@ -104,8 +104,9 @@ Should Guest Network traffic be sent via VPN? (true/false)
 #### wl01_VPNCLIENTNUMBER
 The number of the VPN Client to send traffic through (1-5)
 
-#### wl01_LANACCESS
-Should Guest Network traffic have unrestricted access to the LAN? (true/false)
+#### wl01_TWOWAYTOGUEST
+Should LAN/Guest Network traffic have unrestricted access to each other? (true/false)
+Cannot be enabled if _ONEWAYTOGUEST is enabled
 
 #### wl01_CLIENTISOLATION
 Should Guest Network radio prevent clients from talking to each other? (true/false)

--- a/README.md
+++ b/README.md
@@ -108,5 +108,9 @@ The number of the VPN Client to send traffic through (1-5)
 Should LAN/Guest Network traffic have unrestricted access to each other? (true/false)
 Cannot be enabled if _ONEWAYTOGUEST is enabled
 
+#### wl01_ONEWAYTOGUEST
+Should LAN be able to initiate connections to Guest Network clients (but not the opposite)? (true/false)
+Cannot be enabled if _TWOWAYTOGUEST is enabled
+
 #### wl01_CLIENTISOLATION
 Should Guest Network radio prevent clients from talking to each other? (true/false)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.com/jackyaz/YazFi.svg?branch=master)](https://travis-ci.com/jackyaz/YazFi)
 
 ## v3.3.0
-### Updated on 2020-01-30
+### Updated on 2020-02-02
 ## About
 Feature expansion of guest WiFi networks on AsusWRT-Merlin, including, but not limited to:
 

--- a/YazFi.config.example
+++ b/YazFi.config.example
@@ -25,6 +25,7 @@ wl01_FORCEDNS=true
 wl01_REDIRECTALLTOVPN=true
 wl01_VPNCLIENTNUMBER=2
 wl01_TWOWAYTOGUEST=false
+wl01_ONEWAYTOGUEST=true
 wl01_CLIENTISOLATION=
 ####################################################################
 ######                 Guest Network 2 (wl0.2)                 #####
@@ -39,6 +40,7 @@ wl02_FORCEDNS=false
 wl02_REDIRECTALLTOVPN=false
 wl02_VPNCLIENTNUMBER=
 wl02_TWOWAYTOGUEST=true
+wl02_ONEWAYTOGUEST=false
 wl02_CLIENTISOLATION=
 ####################################################################
 ######                 Guest Network 3 (wl0.3)                 #####
@@ -53,6 +55,7 @@ wl03_FORCEDNS=
 wl03_REDIRECTALLTOVPN=
 wl03_VPNCLIENTNUMBER=
 wl03_TWOWAYTOGUEST=
+wl03_ONEWAYTOGUEST=
 wl03_CLIENTISOLATION=
 ####################################################################
 ######                     5 GHz Networks                     ######
@@ -69,6 +72,7 @@ wl11_FORCEDNS=
 wl11_REDIRECTALLTOVPN=
 wl11_VPNCLIENTNUMBER=
 wl11_TWOWAYTOGUEST=
+wl11_ONEWAYTOGUEST=
 wl11_CLIENTISOLATION=
 ####################################################################
 ######                 Guest Network 2 (wl1.2)                 #####
@@ -83,6 +87,7 @@ wl12_FORCEDNS=
 wl12_REDIRECTALLTOVPN=
 wl12_VPNCLIENTNUMBER=
 wl12_TWOWAYTOGUEST=
+wl12_ONEWAYTOGUEST=
 wl12_CLIENTISOLATION=
 ####################################################################
 ######                 Guest Network 3 (wl1.3)                 #####
@@ -97,6 +102,7 @@ wl13_FORCEDNS=
 wl13_REDIRECTALLTOVPN=
 wl13_VPNCLIENTNUMBER=
 wl13_TWOWAYTOGUEST=
+wl13_ONEWAYTOGUEST=
 wl13_CLIENTISOLATION=
 ####################################################################
 ######                    5 GHz - 2 Networks                  ######
@@ -114,6 +120,7 @@ wl21_FORCEDNS=
 wl21_REDIRECTALLTOVPN=
 wl21_VPNCLIENTNUMBER=
 wl21_TWOWAYTOGUEST=
+wl21_ONEWAYTOGUEST=
 wl21_CLIENTISOLATION=
 ####################################################################
 ######                 Guest Network 2 (wl2.2)                 #####
@@ -128,6 +135,7 @@ wl22_FORCEDNS=
 wl22_REDIRECTALLTOVPN=
 wl22_VPNCLIENTNUMBER=
 wl22_TWOWAYTOGUEST=
+wl22_ONEWAYTOGUEST=
 wl22_CLIENTISOLATION=
 ####################################################################
 ######                 Guest Network 3 (wl2.3)                 #####
@@ -142,5 +150,6 @@ wl23_FORCEDNS=
 wl23_REDIRECTALLTOVPN=
 wl23_VPNCLIENTNUMBER=
 wl23_TWOWAYTOGUEST=
+wl23_ONEWAYTOGUEST=
 wl23_CLIENTISOLATION=
 ####################################################################

--- a/YazFi.config.example
+++ b/YazFi.config.example
@@ -24,7 +24,7 @@ wl01_DNS2=8.8.4.4
 wl01_FORCEDNS=true
 wl01_REDIRECTALLTOVPN=true
 wl01_VPNCLIENTNUMBER=2
-wl01_LANACCESS=false
+wl01_TWOWAYTOGUEST=false
 wl01_CLIENTISOLATION=
 ####################################################################
 ######                 Guest Network 2 (wl0.2)                 #####
@@ -38,7 +38,7 @@ wl02_DNS2=
 wl02_FORCEDNS=false
 wl02_REDIRECTALLTOVPN=false
 wl02_VPNCLIENTNUMBER=
-wl02_LANACCESS=true
+wl02_TWOWAYTOGUEST=true
 wl02_CLIENTISOLATION=
 ####################################################################
 ######                 Guest Network 3 (wl0.3)                 #####
@@ -52,7 +52,7 @@ wl03_DNS2=
 wl03_FORCEDNS=
 wl03_REDIRECTALLTOVPN=
 wl03_VPNCLIENTNUMBER=
-wl03_LANACCESS=
+wl03_TWOWAYTOGUEST=
 wl03_CLIENTISOLATION=
 ####################################################################
 ######                     5 GHz Networks                     ######
@@ -68,7 +68,7 @@ wl11_DNS2=
 wl11_FORCEDNS=
 wl11_REDIRECTALLTOVPN=
 wl11_VPNCLIENTNUMBER=
-wl11_LANACCESS=
+wl11_TWOWAYTOGUEST=
 wl11_CLIENTISOLATION=
 ####################################################################
 ######                 Guest Network 2 (wl1.2)                 #####
@@ -82,7 +82,7 @@ wl12_DNS2=
 wl12_FORCEDNS=
 wl12_REDIRECTALLTOVPN=
 wl12_VPNCLIENTNUMBER=
-wl12_LANACCESS=
+wl12_TWOWAYTOGUEST=
 wl12_CLIENTISOLATION=
 ####################################################################
 ######                 Guest Network 3 (wl1.3)                 #####
@@ -96,7 +96,7 @@ wl13_DNS2=
 wl13_FORCEDNS=
 wl13_REDIRECTALLTOVPN=
 wl13_VPNCLIENTNUMBER=
-wl13_LANACCESS=
+wl13_TWOWAYTOGUEST=
 wl13_CLIENTISOLATION=
 ####################################################################
 ######                    5 GHz - 2 Networks                  ######
@@ -113,7 +113,7 @@ wl21_DNS2=
 wl21_FORCEDNS=
 wl21_REDIRECTALLTOVPN=
 wl21_VPNCLIENTNUMBER=
-wl21_LANACCESS=
+wl21_TWOWAYTOGUEST=
 wl21_CLIENTISOLATION=
 ####################################################################
 ######                 Guest Network 2 (wl2.2)                 #####
@@ -127,7 +127,7 @@ wl22_DNS2=
 wl22_FORCEDNS=
 wl22_REDIRECTALLTOVPN=
 wl22_VPNCLIENTNUMBER=
-wl22_LANACCESS=
+wl22_TWOWAYTOGUEST=
 wl22_CLIENTISOLATION=
 ####################################################################
 ######                 Guest Network 3 (wl2.3)                 #####
@@ -141,6 +141,6 @@ wl23_DNS2=
 wl23_FORCEDNS=
 wl23_REDIRECTALLTOVPN=
 wl23_VPNCLIENTNUMBER=
-wl23_LANACCESS=
+wl23_TWOWAYTOGUEST=
 wl23_CLIENTISOLATION=
 ####################################################################

--- a/YazFi.sh
+++ b/YazFi.sh
@@ -26,8 +26,8 @@
 readonly YAZFI_NAME="YazFi"
 readonly OLD_YAZFI_CONF="/jffs/configs/$YAZFI_NAME/$YAZFI_NAME.config"
 readonly YAZFI_CONF="/jffs/addons/$YAZFI_NAME.d/config"
-readonly YAZFI_VERSION="v3.2.3"
-readonly YAZFI_BRANCH="master"
+readonly YAZFI_VERSION="v3.3.0"
+readonly YAZFI_BRANCH="develop"
 readonly YAZFI_REPO="https://raw.githubusercontent.com/jackyaz/YazFi/""$YAZFI_BRANCH""/YazFi"
 ### End of script variables ###
 

--- a/YazFi.sh
+++ b/YazFi.sh
@@ -27,7 +27,7 @@ readonly YAZFI_NAME="YazFi"
 readonly OLD_YAZFI_CONF="/jffs/configs/$YAZFI_NAME/$YAZFI_NAME.config"
 readonly YAZFI_CONF="/jffs/addons/$YAZFI_NAME.d/config"
 readonly YAZFI_VERSION="v3.3.0"
-readonly YAZFI_BRANCH="develop"
+readonly YAZFI_BRANCH="master"
 readonly YAZFI_REPO="https://raw.githubusercontent.com/jackyaz/YazFi/""$YAZFI_BRANCH""/YazFi"
 ### End of script variables ###
 

--- a/YazFi.sh
+++ b/YazFi.sh
@@ -803,6 +803,18 @@ Firewall_Rules(){
 			iptables -D "$FWRD" -i "$IFACE" ! -o "$IFACE_WAN" -j "$LGRJT"
 		fi
 		
+		if [ "$(eval echo '$'"$(Get_Iface_Var "$IFACE")""_ONEWAYTOGUEST")" = "true" ]; then
+			iptables "$ACTION" "$FWRD" ! -i "$IFACE_WAN" -o "$IFACE" -j ACCEPT
+			iptables "$ACTION" "$FWRD" -i "$IFACE" ! -o "$IFACE_WAN" -m state --state RELATED,ESTABLISHED -j ACCEPT
+		else
+			iptables -D "$FWRD" ! -i "$IFACE_WAN" -o "$IFACE" -j ACCEPT
+			iptables -D "$FWRD" -i "$IFACE" ! -o "$IFACE_WAN" -m state --state RELATED,ESTABLISHED -j ACCEPT
+		fi
+		
+		if [ "$(eval echo '$'"$(Get_Iface_Var "$IFACE")""_TWOWAYTOGUEST")" = "false" ] && [ "$(eval echo '$'"$(Get_Iface_Var "$IFACE")""_ONEWAYTOGUEST")" = "true" ]; then
+			iptables -D "$FWRD" ! -i "$IFACE_WAN" -o "$IFACE" -j "$LGRJT"
+		fi
+		
 		iptables "$ACTION" "$INPT" -i "$IFACE" -j "$LGRJT"
 		iptables "$ACTION" "$INPT" -i "$IFACE" -p icmp -j ACCEPT
 		iptables "$ACTION" "$INPT" -i "$IFACE" -p udp -m multiport --dports 67,123 -j ACCEPT

--- a/YazFi.sh
+++ b/YazFi.sh
@@ -667,6 +667,10 @@ Conf_Exists(){
 	
 	if [ -f "$YAZFI_CONF" ]; then
 		dos2unix "$YAZFI_CONF"
+		chmod 0644 "$YAZFI_CONF"
+		if [ ! -f "$YAZFI_CONF.bak" ]; then
+			cp -a "$YAZFI_CONF" "$YAZFI_CONF.bak"
+		fi
 		sed -i -e 's/_LANACCESS/_TWOWAYTOGUEST/g' "$YAZFI_CONF"
 		if ! grep -q "_ONEWAYTOGUEST" "$YAZFI_CONF" ; then
 			for CONFIFACE in $IFACELIST_FULL ; do
@@ -674,7 +678,6 @@ Conf_Exists(){
 				sed -i "/^$CONFIFACETMP""_TWOWAYTOGUEST=/a $CONFIFACETMP""_ONEWAYTOGUEST=" "$YAZFI_CONF"
 			done
 		fi
-		chmod 0644 "$YAZFI_CONF"
 		sed -i -e 's/"//g' "$YAZFI_CONF"
 		. "$YAZFI_CONF"
 		return 0

--- a/YazFi.sh
+++ b/YazFi.sh
@@ -584,11 +584,11 @@ Conf_Validate(){
 						fi
 					fi
 					
-					# Validate _LANACCESS
-					if [ -z "$(eval echo '$'"$IFACETMP""_LANACCESS")" ]; then
-						sed -i -e "s/""$IFACETMP""_LANACCESS=/""$IFACETMP""_LANACCESS=false/" "$YAZFI_CONF"
-						Print_Output "false" "$IFACETMP""_LANACCESS is blank, setting to false" "$WARN"
-					elif ! Validate_TrueFalse "$IFACETMP""_LANACCESS" "$(eval echo '$'"$IFACETMP""_LANACCESS")"; then
+					# Validate _TWOWAYTOGUEST
+					if [ -z "$(eval echo '$'"$IFACETMP""_TWOWAYTOGUEST")" ]; then
+						sed -i -e "s/""$IFACETMP""_TWOWAYTOGUEST=/""$IFACETMP""_TWOWAYTOGUEST=false/" "$YAZFI_CONF"
+						Print_Output "false" "$IFACETMP""_TWOWAYTOGUEST is blank, setting to false" "$WARN"
+					elif ! Validate_TrueFalse "$IFACETMP""_TWOWAYTOGUEST" "$(eval echo '$'"$IFACETMP""_TWOWAYTOGUEST")"; then
 						IFACE_PASS="false"
 					fi
 					
@@ -652,6 +652,7 @@ Conf_Exists(){
 	fi
 	
 	if [ -f "$YAZFI_CONF" ]; then
+		sed -i -e 's/_LANACCESS/_TWOWAYTOGUEST/g' "$YAZFI_CONF"
 		dos2unix "$YAZFI_CONF"
 		chmod 0644 "$YAZFI_CONF"
 		sed -i -e 's/"//g' "$YAZFI_CONF"
@@ -774,7 +775,7 @@ Firewall_Rules(){
 		
 		iptables "$ACTION" "$FWRD" -i "$IFACE" -j ACCEPT
 		
-		if [ "$(eval echo '$'"$(Get_Iface_Var "$IFACE")""_LANACCESS")" = "false" ]; then
+		if [ "$(eval echo '$'"$(Get_Iface_Var "$IFACE")""_TWOWAYTOGUEST")" = "false" ]; then
 			iptables "$ACTION" "$FWRD" ! -i "$IFACE_WAN" -o "$IFACE" -j "$LGRJT"
 			iptables "$ACTION" "$FWRD" -i "$IFACE" ! -o "$IFACE_WAN" -j "$LGRJT"
 		else


### PR DESCRIPTION
Rename LANACCESS to TWOWAYTOGUEST
Added ONEWAYTOGUEST (see [README](https://github.com/jackyaz/YazFi/blob/master/README.md))
Explicitly block WAN interface in firewall when redirecting to VPN

