### PR TITLE
Allow the execution of a custom script after the default Config_Networks

### DIFF
--- a/YazFi.sh
+++ b/YazFi.sh
@@ -1522,9 +1522,21 @@ Config_Networks(){
 		service restart_wireless >/dev/null 2>&1
 	fi
 	
+	Execute_CustomScript
+	
 	Iface_BounceClients
 	
 	Print_Output "true" "$YAZFI_NAME $YAZFI_VERSION completed successfully" "$PASS"
+}
+
+Execute_CustomScript(){
+	# TODO: Evaluate to incorporate this variable in the config file
+	CUSTOM_SCRIPT_LOCATION="/replace/by/custom/script/location"
+
+	if [ ! -z $CUSTOM_SCRIPT_LOCATION ]; then
+		Print_Output "true" "Executing custom script: $CUSTOM_SCRIPT_LOCATION"
+		sh $CUSTOM_SCRIPT_LOCATION
+	fi
 }
 
 Shortcut_YazFi(){


### PR DESCRIPTION
Hi,

Thank you for your great work!

I found myself executing some custom commands (example: iptables rules to disable internet access on a guest network, forcing another guest network traffic thru Tor, etc), after YazFi executed its own logic.
It seemed more logical to try and incorporate a custom script execution capability inside the YazFi script.

Hope to have placed the script calling in the right place, and maybe it can be useful for others.

Thank you!

PS: I know that the most appropriate place to put the script location path is in the configuration file.
If you find the whole feature useful, I can update the code according to your instructions.