### PR TITLE
add: port 68 to INPUT chain

### DIFF
--- a/YazFi.sh
+++ b/YazFi.sh
@@ -1358,7 +1358,7 @@ Firewall_Rules(){
 		
 		iptables "$ACTION" "$INPT" -i "$IFACE" -j "$LGRJT"
 		iptables "$ACTION" "$INPT" -i "$IFACE" -p icmp -j ACCEPT
-		iptables "$ACTION" "$INPT" -i "$IFACE" -p udp -m multiport --dports 67,123 -j ACCEPT
+		iptables "$ACTION" "$INPT" -i "$IFACE" -p udp -m multiport --dports 67,68,123 -j ACCEPT
 		
 		ENABLED_WINS="$(nvram get smbd_wins)"
 		ENABLED_SAMBA="$(nvram get enable_samba)"


### PR DESCRIPTION
Upon reviewing firewall rules and using `tcpdump` it might be worthwhile to add port 68

## tcpdump
```
tcpdump -i wl0.1 port 67 or port 68 -e -n -vv
```