### PR TITLE
added rule to separate guest networks

### DIFF
--- a/YazFi.sh
+++ b/YazFi.sh
@@ -1628,9 +1628,11 @@ Firewall_Rules(){
 		
 		if [ "$(eval echo '$'"$(Get_Iface_Var "$IFACE")_ONEWAYTOGUEST")" = "true" ]; then
 			iptables "$ACTION" "$FWRD" ! -i "$IFACE_WAN" -o "$IFACE" -j ACCEPT
+			iptables "$ACTION" "$FWRD" -i wl+ -o "$IFACE" -j "$LGRJT"
 			iptables "$ACTION" "$FWRD" -i "$IFACE" ! -o "$IFACE_WAN" -m state --state RELATED,ESTABLISHED -j ACCEPT
 		else
 			iptables -D "$FWRD" ! -i "$IFACE_WAN" -o "$IFACE" -j ACCEPT
+			iptables -D "$FWRD" -i wl+ -o "$IFACE" -j "$LGRJT"
 			iptables -D "$FWRD" -i "$IFACE" ! -o "$IFACE_WAN" -m state --state RELATED,ESTABLISHED -j ACCEPT
 		fi
 		


### PR DESCRIPTION
With this iptables rule even if "One way to guest" is used guest networks are still separated from each other. see: https://www.snbforums.com/threads/yazfi-isolation-of-guest-networks.84654/

Without this change it is possible for devices in some guest networks to access devices in other guest networks if "one way to guest" is enabled.
This was restricted with the following iptable rule:
iptables -I YazFiFORWARD 9 -i wl+ -o wl0.2 -j YazFiREJECT


Sorry, this is my first git pull request. Please let me know in case I do it wrong. Thanks!